### PR TITLE
Using LittleFS and minor bug fixes Compiler's warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 
 ## Features and Improvements added by Tuan_Karma (Anthony)
 
-- [ ] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
+- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
 - [ ] Code improvements to eliminate Compiler's warnings
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 ## Features and Improvements added by Tuan_Karma (Anthony)
 
 - [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
-- [ ] Code improvements to eliminate Compiler's warnings
+- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`
 
 ## How it works
 

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -21,7 +21,6 @@
 #include <HTTPClient.h>
 #include <Update.h>
 #include "ArduinoJson.h"
-// #include <FS.h>
 #include <LittleFS.h>
 
 

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -21,7 +21,7 @@
 #include <HTTPClient.h>
 #include <Update.h>
 #include "ArduinoJson.h"
-#include <FS.h>
+// #include <FS.h>
 #include <LittleFS.h>
 
 

--- a/src/semver/semver.c
+++ b/src/semver/semver.c
@@ -499,7 +499,7 @@ semver_free (semver_t *x) {
  */
 
 static void
-concat_num (char * str, int x, char * sep) {
+concat_num (char * str, int x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   if (sep == NULL) sprintf(buf, "%d", x);
   else sprintf(buf, "%s%d", sep, x);
@@ -507,7 +507,7 @@ concat_num (char * str, int x, char * sep) {
 }
 
 static void
-concat_char (char * str, char * x, char * sep) {
+concat_char (char * str, char * x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   sprintf(buf, "%s%s", sep, x);
   strcat(str, buf);


### PR DESCRIPTION
Changes: 
- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`

Limitations:
- No limitations added.

Tested:
- on ESP32 devboards.